### PR TITLE
feat: allow to parse inline certs in the config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,33 @@ SPDX-License-Identifier: GPL-3.0-or-later
 proxy-obfs4 obfs4://RHOST:RPORT?cert=BASE64ENCODED_CERT&iat-mode=0
 ```
 
+## Configuration
+
+The public constructor for `vpn.CLient` allows you to instantiate a `Client` from a
+correctly initialized `Options` object.
+
+For convenience, `minivpn` also understands how to parse a minimal subset of the
+configuration options that can be written in an openvpn config file.
+
+### Inline file support
+
+Following the configuration format in the reference implementation, `minivpn`
+allows including files in the main configuration file, but only for the ` ca`,
+`cert` and `key` options.
+
+Each inline file is started by the line <option> and ended by the line
+</option>.
+
+Here is an example of an inline file usage:
+
+```
+<cert>
+-----BEGIN CERTIFICATE-----
+[...]
+-----END CERTIFICATE-----
+</cert>
+```
+
 ## Tests
 
 You can run a `connect+ping` test against a given provider (but be aware that

--- a/vpn/data_test.go
+++ b/vpn/data_test.go
@@ -92,11 +92,11 @@ func makeTestingSession() *session {
 func makeTestingOptions(t *testing.T, cipher, auth string) *Options {
 	crt, _ := writeTestingCerts(t.TempDir())
 	opt := &Options{
-		Cipher: cipher,
-		Auth:   auth,
-		Cert:   crt.cert,
-		Key:    crt.key,
-		Ca:     crt.ca,
+		Cipher:   cipher,
+		Auth:     auth,
+		CertPath: crt.cert,
+		KeyPath:  crt.key,
+		CaPath:   crt.ca,
 	}
 	return opt
 }

--- a/vpn/dialer_test.go
+++ b/vpn/dialer_test.go
@@ -127,6 +127,7 @@ func makeTestingClient(opt *Options) vpnClient {
 	client := &Client{Opts: opt}
 	client.conn = makeTestingConnForHandshake("udp", "10.0.0.1", 42)
 	client.tunnel = &tunnel{ip: "10.0.0.1", mtu: 1500}
+	client.mux = &mockMuxerForClient{}
 	return client
 }
 
@@ -370,7 +371,6 @@ func TestTunDialer_DialContext(t *testing.T) {
 			},
 			wantErr: nil,
 		},
-		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -391,23 +391,17 @@ func TestTunDialer_DialContext(t *testing.T) {
 	}
 }
 
-func TestNewRawDialer(t *testing.T) {
-	type args struct {
-		opts *Options
+func Test_RawDialerDial(t *testing.T) {
+	raw := makeTestingRawDialer(t)
+	raw.clientFactory = makeTestingClient
+	mockedRaw := &mockRawDialer{raw}
+	_, err := mockedRaw.Dial()
+	if err != nil {
+		t.Errorf("mocked dialer should not raise error: %v", err)
 	}
-	tests := []struct {
-		name string
-		args args
-		want *RawDialer
-	}{
-		// TODO: Add test cases.
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := NewRawDialer(tt.args.opts); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewRawDialer() = %v, want %v", got, tt.want)
-			}
-		})
+	_, err = mockedRaw.DialContext(context.Background())
+	if err != nil {
+		t.Errorf("mocked dialer should not raise error: %v", err)
 	}
 }
 

--- a/vpn/muxer.go
+++ b/vpn/muxer.go
@@ -124,9 +124,11 @@ type dataHandler interface {
 // muxer initialization
 //
 
+type muxFactory func(conn net.Conn, options *Options, tunnel *tunnel) (vpnMuxer, error)
+
 // newMuxerFromOptions returns a configured muxer, and any error if the
 // operation could not be completed.
-func newMuxerFromOptions(conn net.Conn, options *Options, tunnel *tunnel) (*muxer, error) {
+func newMuxerFromOptions(conn net.Conn, options *Options, tunnel *tunnel) (vpnMuxer, error) {
 	control := &control{}
 	session, err := newSession()
 	if err != nil {
@@ -182,7 +184,7 @@ func (m *muxer) handshake() error {
 	// 2. TLS handshake.
 
 	// TODO(ainghazal): move the initialization step to an early phase and keep a ref in the muxer
-	if m.options.Cert == "" && m.options.Key == "" && m.options.Username == "" {
+	if !m.options.HasAuthInfo() {
 		return fmt.Errorf("%w: %s", errBadInput, "expected certificate or username/password")
 	}
 	certCfg, err := newCertConfigFromOptions(m.options)
@@ -345,26 +347,26 @@ func (m *muxer) readAndLoadRemoteKey() error {
 		return err
 	}
 	if !isControlMessage(data) {
-		return fmt.Errorf("%w:%s", errBadControlMessage, "expected null header")
+		return fmt.Errorf("%w: %s", errBadControlMessage, "expected null header")
 	}
 
 	// Parse the received data: we expect remote key and remote options.
 	remoteKey, opts, err := m.control.ReadControlMessage(data)
 	if err != nil {
 		logger.Errorf("cannot parse control message")
-		return fmt.Errorf("%w:%s", ErrBadHandshake, err)
+		return fmt.Errorf("%w: %s", ErrBadHandshake, err)
 	}
 
 	// Store the remote key.
 	key, err := m.session.ActiveKey()
 	if err != nil {
 		logger.Errorf("cannot get active key")
-		return fmt.Errorf("%w:%s", ErrBadHandshake, err)
+		return fmt.Errorf("%w: %s", ErrBadHandshake, err)
 	}
 	err = key.addRemoteKey(remoteKey)
 	if err != nil {
 		logger.Errorf("cannot add remote key")
-		return fmt.Errorf("%w:%s", ErrBadHandshake, err)
+		return fmt.Errorf("%w: %s", ErrBadHandshake, err)
 	}
 
 	// Parse and store the useful parts of the remote options.

--- a/vpn/options_test.go
+++ b/vpn/options_test.go
@@ -2,7 +2,6 @@ package vpn
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	fp "path/filepath"
 	"reflect"
@@ -80,9 +79,9 @@ func TestOptions_String(t *testing.T) {
 				Proto:      tt.fields.Proto,
 				Username:   tt.fields.Username,
 				Password:   tt.fields.Password,
-				Ca:         tt.fields.Ca,
-				Cert:       tt.fields.Cert,
-				Key:        tt.fields.Key,
+				CaPath:     tt.fields.Ca,
+				CertPath:   tt.fields.Cert,
+				KeyPath:    tt.fields.Key,
 				Compress:   tt.fields.Compress,
 				Cipher:     tt.fields.Cipher,
 				Auth:       tt.fields.Auth,
@@ -110,14 +109,40 @@ func TestGetOptionsFromLines(t *testing.T) {
 	writeDummyCertFiles(d)
 	o, err := getOptionsFromLines(l, d)
 	if err != nil {
-		fmt.Println("error:", err)
-		t.Errorf("Good options should not fail")
+		t.Errorf("Good options should not fail: %s", err)
 	}
 	if o.Cipher != "AES-256-GCM" {
 		t.Errorf("Cipher not what expected")
 	}
 	if o.Auth != "SHA512" {
 		t.Errorf("Auth not what expected")
+	}
+}
+
+func TestGetOptionsFromLinesInlineCerts(t *testing.T) {
+	l := []string{
+		"<ca>",
+		"ca_string",
+		"</ca>",
+		"<cert>",
+		"cert_string",
+		"</cert>",
+		"<key>",
+		"key_string",
+		"</key>",
+	}
+	o, err := getOptionsFromLines(l, "")
+	if err != nil {
+		t.Errorf("Good options should not fail: %s", err)
+	}
+	if string(o.Ca) != "ca_string\n" {
+		t.Errorf("Expected ca_string, got: %s.", string(o.Ca))
+	}
+	if string(o.Cert) != "cert_string\n" {
+		t.Errorf("Expected cert_string, got: %s.", string(o.Cert))
+	}
+	if string(o.Key) != "key_string\n" {
+		t.Errorf("Expected key_string, got: %s.", string(o.Key))
 	}
 }
 


### PR DESCRIPTION
In order to support constructing a single config file it's convenient to be able to pass inline certs, as OpenVPN itself does.
These certs are identified by html-like tags: 

```
<ca>, <key>, <cert>
```

While working on this feature, I also:

- improved test coverage in unrelated parts
- made the ping stats also return more fields according to the latest spec.