### PR TITLE
refactor: cleanup public API

### DIFF
--- a/cmd/ndt7/main.go
+++ b/cmd/ndt7/main.go
@@ -35,7 +35,7 @@ func main() {
 	optCnt := getopt.IntLong("count", 'c', 1, "Repetitions count (default: 1)")
 	getopt.Parse()
 
-	opts, err := vpn.ParseConfigFile("data/" + provider + "/config")
+	opts, err := vpn.NewOptionsFromFilePath("data/" + provider + "/config")
 	if err != nil {
 		panic(err)
 	}
@@ -75,7 +75,7 @@ func main() {
 		log.Println("Run:", i)
 		log.Println()
 		if *optExp == "all" || *optExp == "download" {
-			dialer := vpn.NewTunDialerFromOptions(opts)
+			dialer := vpn.StartNewTunDialerFromOptions(opts)
 			if opts.ProxyOBFS4 != "" {
 				if direct {
 					log.Fatal("Cannot use proxy-obfs4 and BASE=1 at the same time")
@@ -98,7 +98,7 @@ func main() {
 
 		}
 		if *optExp == "all" || *optExp == "upload" {
-			dialer := vpn.NewTunDialerFromOptions(opts)
+			dialer := vpn.StartNewTunDialerFromOptions(opts)
 			if opts.ProxyOBFS4 != "" {
 				if direct {
 					log.Fatal("Cannot use proxy-obfs4 and BASE=1 at the same time")

--- a/cmd/obfs4vpn/main.go
+++ b/cmd/obfs4vpn/main.go
@@ -18,7 +18,7 @@ func main() {
 	if provider == "" {
 		log.Fatal("Export the PROVIDER variable")
 	}
-	opts, err := vpn.ParseConfigFile("data/" + provider + "/config")
+	opts, err := vpn.NewOptionsFromFilePath("data/" + provider + "/config")
 	if err != nil {
 		panic(err)
 	}
@@ -35,7 +35,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	dialer := vpn.NewTunDialerFromOptions(opts)
+	dialer := vpn.StartNewTunDialerFromOptions(opts)
 
 	var obfs4Dialer vpn.DialerContext = obfs4.NewDialer(node)
 	dialer.Dialer = obfs4Dialer

--- a/cmd/vpnping/main.go
+++ b/cmd/vpnping/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	opts, err := vpn.ParseConfigFile("data/riseup/config")
+	opts, err := vpn.NewOptionsFromFilePath("data/riseup/config")
 	if err != nil {
 		panic(err)
 	}

--- a/extras/example_pinger_test.go
+++ b/extras/example_pinger_test.go
@@ -16,16 +16,13 @@ var (
 )
 
 func ExamplePinger() {
-	opts, err := vpn.ParseConfigFile(cfg)
+	opts, err := vpn.NewOptionsFromFilePath(cfg)
 	if err != nil {
 		os.Exit(1)
 	}
-	rawDialer := vpn.NewRawDialer(opts)
-	conn, err := rawDialer.Dial()
-	if err != nil {
-		panic(err)
-	}
-	pinger := ping.New(target, conn)
+	tunnel := vpn.NewClientFromOptions(opts)
+	tunnel.Start(context.Background())
+	pinger := ping.New(target, tunnel)
 	pinger.Count = 3
 	pinger.Timeout = 5 * time.Second
 	pinger.Run(context.Background())

--- a/go.mod
+++ b/go.mod
@@ -19,8 +19,8 @@ require (
 	github.com/pborman/getopt/v2 v2.1.0
 	github.com/refraction-networking/utls v1.1.0
 	gitlab.com/yawning/obfs4.git v0.0.0-20220204003609-77af0cba934d
-	golang.org/x/net v0.0.0-20220706163947-c90051bbdb60
-	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
+	golang.org/x/net v0.0.0-20220722155237-a158d28d115b
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	golang.zx2c4.com/wireguard v0.0.0-20220703234212-c31a7b1ab478
 	golang.zx2c4.com/wireguard/tun/netstack v0.0.0-20220703234212-c31a7b1ab478
 )
@@ -56,7 +56,7 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd // indirect
-	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
+	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	golang.zx2c4.com/wintun v0.0.0-20211104114900-415007cec224 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -809,8 +809,8 @@ golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
-golang.org/x/net v0.0.0-20220706163947-c90051bbdb60 h1:8NSylCMxLW4JvserAndSgFL7aPli6A68yf0bYFTcWCM=
-golang.org/x/net v0.0.0-20220706163947-c90051bbdb60/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.0.0-20220722155237-a158d28d115b h1:PxfKdU9lEEDYjdIzOtC4qFWgkU2rGHdKlKowJSMN9h0=
+golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -834,8 +834,8 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f h1:Ax0t5p6N38Ga0dThY21weqDEyz2oklo4IvDkpigvkD8=
-golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -915,8 +915,9 @@ golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220315194320-039c03cc5b86/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220405210540-1e041c57c461/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
+golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/proxy.go
+++ b/proxy.go
@@ -27,7 +27,10 @@ func ListenAndServeSocks(opts *vpn.Options) {
 	if ip == "" {
 		ip = socksIP
 	}
-	dialer := vpn.NewTunDialerFromOptions(opts)
+	dialer, err := vpn.StartNewTunDialerFromOptions(opts)
+	if err != nil {
+		panic(err)
+	}
 	conf := &socks5.Config{
 		Dial: dialer.DialContext,
 	}

--- a/tests/integration/openvpn_test.go
+++ b/tests/integration/openvpn_test.go
@@ -148,19 +148,16 @@ func TestClientAES256GCM(t *testing.T) {
 	// can assert that this is a remote line
 
 	// actual test begins
-	opt, err := vpn.ParseConfigFile(filepath.Join(tmp, "config"))
+	opt, err := vpn.NewOptionsFromFilePath(filepath.Join(tmp, "config"))
 	if err != nil {
 		log.Fatalf("Could not parse file: %s", err)
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	rawDialer := vpn.NewRawDialer(opt)
-	conn, err := rawDialer.DialContext(ctx)
-	if err != nil {
-		log.Fatalf("cannot dial: %s", err)
-	}
-	pinger := ping.New(target, conn)
+	tunnel := vpn.NewClientFromOptions(opt)
+	tunnel.Start(ctx)
+	pinger := ping.New(target, tunnel)
 	pinger.Count = count
 	err = pinger.Run(ctx)
 	defer pinger.Stop()

--- a/vpn/doc.go
+++ b/vpn/doc.go
@@ -1,5 +1,21 @@
+//
 // Package vpn contains the API to create an OpenVPN client that can connect to
 // a remote OpenVPN endpoint and provide you with a tunnel where to send packets.
 //
-// The recommended way to use this package is to use the dialer methods.
+// The recommended way to use this package is to use the TunDialer
+// constructors, that gives you a way to transparently Dial() and get TCP or
+// UDP sockets over a virtual gVisor interface, that uses the VPN tunnel as an
+// underlying transport. For examples, see the `proxy' implementation in the
+// `extras` package.
+//
+// If you need to write raw packets to the tunnel instead, you can construct
+// and use a `Client` object directly. `Client` is an implementer of the
+// `net.Conn` interface. You need to `Start()` the Client before you can Read
+// or Write packets to it. An example of this can be found in the `extras/ping`
+// package.
+//
+// Reads and Writes to the Client tunnel object are
+// actually reading and writing to the initialized Data channel of the Client.
+// Any incoming packet while reading that is not an OpenVPN data packet will be
+// dispatched accordingly.
 package vpn

--- a/vpn/muxer_test.go
+++ b/vpn/muxer_test.go
@@ -21,7 +21,7 @@ func Test_newMuxerFromOptions(t *testing.T) {
 	type args struct {
 		conn    net.Conn
 		options *Options
-		tunnel  *tunnel
+		tunnel  *tunnelInfo
 	}
 	tests := []struct {
 		name    string
@@ -34,7 +34,7 @@ func Test_newMuxerFromOptions(t *testing.T) {
 			args: args{
 				conn:    makeTestingConnForWrite("udp", "10.0.42.2", 42),
 				options: makeTestingOptions(t, "AES-128-GCM", "sha1"),
-				tunnel:  &tunnel{},
+				tunnel:  &tunnelInfo{},
 			},
 			want: &muxer{
 				conn:    makeTestingConnForWrite("udp", "10.0.42.2", 42),
@@ -107,6 +107,9 @@ func makeTestingConnForHandshake(network, addr string, n int) net.Conn {
 
 		return 0, nil
 	}
+	c.MockClose = func() error {
+		return nil
+	}
 	return c
 }
 
@@ -140,7 +143,7 @@ func Test_muxer_Handshake(t *testing.T) {
 	m := &mockMuxerForHandshake{}
 	m.control = &control{}
 	m.data = makeData()
-	m.tunnel = &tunnel{}
+	m.tunnel = &tunnelInfo{}
 	s, err := newSession()
 	if err != nil {
 		t.Error("session failed, cannot run handshake test")
@@ -163,7 +166,7 @@ func Test_muxer_Handshake(t *testing.T) {
 	initTLSFn = func(*session, *certConfig) (*tls.Config, error) {
 		return &tls.Config{InsecureSkipVerify: true}, nil
 	}
-	tlsHandshakeFn = func(tc *TLSConn, tconf *tls.Config) (net.Conn, error) {
+	tlsHandshakeFn = func(tc *controlChannelTLSConn, tconf *tls.Config) (net.Conn, error) {
 		return m.conn, nil
 	}
 
@@ -436,7 +439,7 @@ func Test_muxer_readTLSPacket(t *testing.T) {
 		data      dataHandler
 		bufReader *bytes.Buffer
 		session   *session
-		tunnel    *tunnel
+		tunnel    *tunnelInfo
 		options   *Options
 	}
 	tests := []struct {
@@ -479,7 +482,7 @@ func Test_muxer_readAndLoadRemoteKey(t *testing.T) {
 		data      dataHandler
 		bufReader *bytes.Buffer
 		session   *session
-		tunnel    *tunnel
+		tunnel    *tunnelInfo
 		options   *Options
 	}
 	tests := []struct {
@@ -516,7 +519,7 @@ func Test_muxer_readPushReply(t *testing.T) {
 		data      dataHandler
 		bufReader *bytes.Buffer
 		session   *session
-		tunnel    *tunnel
+		tunnel    *tunnelInfo
 		options   *Options
 	}
 	tests := []struct {

--- a/vpn/options_test.go
+++ b/vpn/options_test.go
@@ -90,7 +90,7 @@ func TestOptions_String(t *testing.T) {
 				Log:        tt.fields.Log,
 			}
 			if got := o.String(); got != tt.want {
-				t.Errorf("Options.String() = %v, want %v", got, tt.want)
+				t.Errorf("Options.string() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -287,7 +287,7 @@ func Test_ParseConfigFile(t *testing.T) {
 	if err != nil {
 		t.Fatal("ParseConfigFile(): cannot write cert needed for the test")
 	}
-	o, err := ParseConfigFile(f)
+	o, err := NewOptionsFromFilePath(f)
 	if err != nil {
 		t.Errorf("ParseConfigFile(): expected err=%v, got=%v", nil, err)
 	}
@@ -301,12 +301,12 @@ func Test_ParseConfigFile(t *testing.T) {
 	}
 
 	// expect error when parsing a bad filepath
-	_, err = ParseConfigFile("")
+	_, err = NewOptionsFromFilePath("")
 	if err == nil {
 		t.Errorf("expected error with empty file")
 	}
 
-	_, err = ParseConfigFile("http://example.com")
+	_, err = NewOptionsFromFilePath("http://example.com")
 	if err == nil {
 		t.Errorf("expected error with http uri")
 	}
@@ -469,71 +469,71 @@ func Test_parseOption(t *testing.T) {
 
 func Test_parseRemoteOptions(t *testing.T) {
 	type args struct {
-		tunnel     *tunnel
+		tunnel     *tunnelInfo
 		remoteOpts string
 	}
 	tests := []struct {
 		name string
 		args args
-		want *tunnel
+		want *tunnelInfo
 	}{
 		{
 			name: "parse good tun-mtu",
 			args: args{
-				tunnel:     &tunnel{},
+				tunnel:     &tunnelInfo{},
 				remoteOpts: "foo bar,tun-mtu 1500",
 			},
-			want: &tunnel{
+			want: &tunnelInfo{
 				mtu: 1500,
 			},
 		},
 		{
 			name: "empty string",
 			args: args{
-				tunnel:     &tunnel{mtu: 1500},
+				tunnel:     &tunnelInfo{mtu: 1500},
 				remoteOpts: "",
 			},
-			want: &tunnel{
+			want: &tunnelInfo{
 				mtu: 1500,
 			},
 		},
 		{
 			name: "update value",
 			args: args{
-				tunnel:     &tunnel{mtu: 1500},
+				tunnel:     &tunnelInfo{mtu: 1500},
 				remoteOpts: "tun-mtu 1200",
 			},
-			want: &tunnel{
+			want: &tunnelInfo{
 				mtu: 1200,
 			},
 		},
 		{
 			name: "empty field",
 			args: args{
-				tunnel:     &tunnel{mtu: 1500},
+				tunnel:     &tunnelInfo{mtu: 1500},
 				remoteOpts: "tun-mtu 1200,,",
 			},
-			want: &tunnel{
+			want: &tunnelInfo{
 				mtu: 1200,
 			},
 		},
 		{
 			name: "extra space",
 			args: args{
-				tunnel:     &tunnel{mtu: 1500},
+				tunnel:     &tunnelInfo{mtu: 1500},
 				remoteOpts: "tun-mtu  1200",
 			},
-			want: &tunnel{
+			want: &tunnelInfo{
 				mtu: 1500,
 			},
 		},
 		{
 			name: "mtu not an int",
 			args: args{
-				tunnel:     &tunnel{mtu: 1500},
+				tunnel:     &tunnelInfo{mtu: 1500},
 				remoteOpts: "tun-mtu aaa",
 			},
-			want: &tunnel{
+			want: &tunnelInfo{
 				mtu: 1500,
 			},
 		},

--- a/vpn/tls.go
+++ b/vpn/tls.go
@@ -120,7 +120,7 @@ type certConfig struct {
 func newCertConfigFromOptions(o *Options) (*certConfig, error) {
 	var cfg *certConfig
 	var err error
-	if o.CertsFromPath() {
+	if o.certsFromPath() {
 		cfg, err = loadCertAndCAFromPath(certPaths{
 			certPath: o.CertPath,
 			keyPath:  o.KeyPath,
@@ -206,7 +206,7 @@ func initTLS(session *session, cfg *certConfig) (*tls.Config, error) {
 
 // tlsHandshake performs the TLS handshake over the control channel, and return
 // the TLS Client as a net.Conn; returns also any error during the handshake.
-func tlsHandshake(tlsConn *TLSConn, tlsConf *tls.Config) (net.Conn, error) {
+func tlsHandshake(tlsConn *controlChannelTLSConn, tlsConf *tls.Config) (net.Conn, error) {
 	tlsClient, err := tlsFactoryFn(tlsConn, tlsConf)
 	if err != nil {
 		return nil, err

--- a/vpn/tls_test.go
+++ b/vpn/tls_test.go
@@ -549,10 +549,10 @@ func errorRaisingTLSFactory(net.Conn, *tls.Config) (handshaker, error) {
 
 func Test_tlsHandshake(t *testing.T) {
 
-	makeConnAndConf := func() (*TLSConn, *tls.Config) {
+	makeConnAndConf := func() (*controlChannelTLSConn, *tls.Config) {
 		conn := &mocks.Conn{}
 		s := makeTestingSession()
-		tc, _ := NewTLSConn(conn, s)
+		tc, _ := newControlChannelTLSConn(conn, s)
 
 		conf := &tls.Config{
 			InsecureSkipVerify: true,


### PR DESCRIPTION
Clean up the public interface and remove the unnecessary indirection layer caused by RawDialer.
Update tests accordingly.