### PR TITLE
 refactor: introduce tun 

### DIFF
--- a/internal/tun/doc.go
+++ b/internal/tun/doc.go
@@ -1,0 +1,3 @@
+// Package tun is the public interface for the minivpn application. It exposes a tun device interface
+// where the user of the application can write to and read from.
+package tun

--- a/internal/tun/setup.go
+++ b/internal/tun/setup.go
@@ -47,9 +47,6 @@ func startWorkers(logger model.Logger, sessionManager *session.Manager,
 		NetworkToMuxer:       make(chan []byte),
 	}
 
-	// tell the packetmuxer that it should handshake ASAP
-	muxer.HardReset <- true
-
 	// connect networkio and packetmuxer
 	connectChannel(nio.MuxerToNetwork, &muxer.MuxerToNetwork)
 	connectChannel(muxer.NetworkToMuxer, &nio.NetworkToMuxer)
@@ -124,6 +121,9 @@ func startWorkers(logger model.Logger, sessionManager *session.Manager,
 	ctrl.StartWorkers(logger, workersManager, sessionManager)
 	datach.StartWorkers(logger, workersManager, sessionManager, options)
 	tlsx.StartWorkers(logger, workersManager, sessionManager, options)
+
+	// tell the packetmuxer that it should handshake ASAP
+	muxer.HardReset <- true
 
 	return workersManager
 }

--- a/internal/tun/setup.go
+++ b/internal/tun/setup.go
@@ -1,0 +1,130 @@
+package tun
+
+import (
+	"github.com/ooni/minivpn/internal/controlchannel"
+	"github.com/ooni/minivpn/internal/datachannel"
+	"github.com/ooni/minivpn/internal/model"
+	"github.com/ooni/minivpn/internal/networkio"
+	"github.com/ooni/minivpn/internal/packetmuxer"
+	"github.com/ooni/minivpn/internal/reliabletransport"
+	"github.com/ooni/minivpn/internal/runtimex"
+	"github.com/ooni/minivpn/internal/session"
+	"github.com/ooni/minivpn/internal/tlssession"
+	"github.com/ooni/minivpn/internal/workers"
+)
+
+// connectChannel connects an existing channel (a "signal" in Qt terminology)
+// to a nil pointer to channel (a "slot" in Qt terminology).
+func connectChannel[T any](signal chan T, slot **chan T) {
+	runtimex.Assert(signal != nil, "signal is nil")
+	runtimex.Assert(slot == nil || *slot == nil, "slot or *slot aren't nil")
+	*slot = &signal
+}
+
+// startWorkers starts all the workers.  See the [ARCHITECTURE]
+// file for more information about the workers.
+//
+// [ARCHITECTURE]: https://github.com/ooni/minivpn/blob/main/ARCHITECTURE.md
+func startWorkers(logger model.Logger, sessionManager *session.Manager,
+	tunDevice *TUN,
+	conn networkio.FramingConn, options *model.Options) *workers.Manager {
+	// create a workers manager
+	workersManager := workers.NewManager()
+
+	// create the networkio service.
+	nio := &networkio.Service{
+		MuxerToNetwork: make(chan []byte, 1<<5),
+		NetworkToMuxer: nil, // ok
+	}
+
+	// create the packetmuxer service.
+	muxer := &packetmuxer.Service{
+		MuxerToReliable:      nil, // ok
+		MuxerToData:          nil, // ok
+		NotifyTLS:            nil,
+		HardReset:            make(chan any, 1),
+		DataOrControlToMuxer: make(chan *model.Packet),
+		MuxerToNetwork:       nil, // ok
+		NetworkToMuxer:       make(chan []byte),
+	}
+
+	// tell the packetmuxer that it should handshake ASAP
+	muxer.HardReset <- true
+
+	// connect networkio and packetmuxer
+	connectChannel(nio.MuxerToNetwork, &muxer.MuxerToNetwork)
+	connectChannel(muxer.NetworkToMuxer, &nio.NetworkToMuxer)
+
+	// create the datachannel service.
+	datach := &datachannel.Service{
+		MuxerToData:          make(chan *model.Packet),
+		DataOrControlToMuxer: nil, // ok
+		KeyReady:             make(chan *session.DataChannelKey, 1),
+		TUNToData:            tunDevice.TunDown,
+		DataToTUN:            tunDevice.TunUp,
+	}
+
+	// connect the packetmuxer and the datachannel
+	connectChannel(datach.MuxerToData, &muxer.MuxerToData)
+	connectChannel(muxer.DataOrControlToMuxer, &datach.DataOrControlToMuxer)
+
+	// create the reliabletransport service.
+	rel := &reliabletransport.Service{
+		DataOrControlToMuxer: nil, // ok
+		ControlToReliable:    make(chan *model.Packet),
+		MuxerToReliable:      make(chan *model.Packet),
+		ReliableToControl:    nil, // ok
+	}
+
+	// connect reliable service and packetmuxer.
+	connectChannel(rel.MuxerToReliable, &muxer.MuxerToReliable)
+	connectChannel(muxer.DataOrControlToMuxer, &rel.DataOrControlToMuxer)
+
+	// create the controlchannel service.
+	ctrl := &controlchannel.Service{
+		NotifyTLS:            nil, // ok
+		ControlToReliable:    nil, // ok
+		ReliableToControl:    make(chan *model.Packet),
+		TLSRecordToControl:   make(chan []byte),
+		TLSRecordFromControl: nil, // ok
+	}
+
+	// connect the reliable service and the controlchannel service
+	connectChannel(rel.ControlToReliable, &ctrl.ControlToReliable)
+	connectChannel(ctrl.ReliableToControl, &rel.ReliableToControl)
+
+	// create the tlssession service
+	tlsx := &tlssession.Service{
+		NotifyTLS:     make(chan *model.Notification, 1),
+		KeyUp:         nil,
+		TLSRecordUp:   make(chan []byte),
+		TLSRecordDown: nil,
+	}
+
+	// connect the tlsstate service and the controlchannel service
+	connectChannel(tlsx.NotifyTLS, &ctrl.NotifyTLS)
+	connectChannel(tlsx.TLSRecordUp, &ctrl.TLSRecordFromControl)
+	connectChannel(ctrl.TLSRecordToControl, &tlsx.TLSRecordDown)
+
+	// connect tlsstate service and the datachannel service
+	connectChannel(datach.KeyReady, &tlsx.KeyUp)
+
+	// connect the muxer and the tlsstate service
+	connectChannel(tlsx.NotifyTLS, &muxer.NotifyTLS)
+
+	logger.Debugf("%T: %+v", nio, nio)
+	logger.Debugf("%T: %+v", muxer, muxer)
+	logger.Debugf("%T: %+v", rel, rel)
+	logger.Debugf("%T: %+v", ctrl, ctrl)
+	logger.Debugf("%T: %+v", tlsx, tlsx)
+
+	// start all the workers
+	nio.StartWorkers(logger, workersManager, conn)
+	muxer.StartWorkers(logger, workersManager, sessionManager)
+	rel.StartWorkers(logger, workersManager, sessionManager)
+	ctrl.StartWorkers(logger, workersManager, sessionManager)
+	datach.StartWorkers(logger, workersManager, sessionManager, options)
+	tlsx.StartWorkers(logger, workersManager, sessionManager, options)
+
+	return workersManager
+}

--- a/internal/tun/setup.go
+++ b/internal/tun/setup.go
@@ -26,8 +26,7 @@ func connectChannel[T any](signal chan T, slot **chan T) {
 //
 // [ARCHITECTURE]: https://github.com/ooni/minivpn/blob/main/ARCHITECTURE.md
 func startWorkers(logger model.Logger, sessionManager *session.Manager,
-	tunDevice *TUN,
-	conn networkio.FramingConn, options *model.Options) *workers.Manager {
+	tunDevice *TUN, conn networkio.FramingConn, options *model.Options) *workers.Manager {
 	// create a workers manager
 	workersManager := workers.NewManager()
 

--- a/internal/tun/setup.go
+++ b/internal/tun/setup.go
@@ -56,8 +56,8 @@ func startWorkers(logger model.Logger, sessionManager *session.Manager,
 		MuxerToData:          make(chan *model.Packet),
 		DataOrControlToMuxer: nil, // ok
 		KeyReady:             make(chan *session.DataChannelKey, 1),
-		TUNToData:            tunDevice.TunDown,
-		DataToTUN:            tunDevice.TunUp,
+		TUNToData:            tunDevice.tunDown,
+		DataToTUN:            tunDevice.tunUp,
 	}
 
 	// connect the packetmuxer and the datachannel

--- a/internal/tun/tun.go
+++ b/internal/tun/tun.go
@@ -63,7 +63,7 @@ type TUN struct {
 	// used to buffer reads from above.
 	readBuffer *bytes.Buffer
 
-	// used for implemeting deadlines in the net.Conn
+	// used for implementing deadlines in the net.Conn
 	readDeadline     *time.Timer
 	readDeadlineDone chan any
 

--- a/internal/tun/tun.go
+++ b/internal/tun/tun.go
@@ -1,8 +1,5 @@
 package tun
 
-// TODO(ainghazal): this package shares a bunch of code with tlsbio, consider
-// refactoring common parts.
-
 import (
 	"bytes"
 	"context"

--- a/internal/tun/tun.go
+++ b/internal/tun/tun.go
@@ -1,0 +1,176 @@
+package tun
+
+// TODO(ainghazal): this package shares a bunch of code with tlsbio, consider
+// refactoring common parts.
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/apex/log"
+	"github.com/ooni/minivpn/internal/model"
+	"github.com/ooni/minivpn/internal/networkio"
+	"github.com/ooni/minivpn/internal/session"
+)
+
+func StartTUN(conn networkio.FramingConn, options *model.Options) *TUN {
+	// create a session
+	sessionManager, err := session.NewManager(log.Log)
+	if err != nil {
+		log.WithError(err).Fatal("tun.StartTUN")
+	}
+
+	// create the TUN that will OWN the connection
+	tunnel := NewTUN(log.Log, conn, sessionManager)
+
+	// start all the workers
+	workers := startWorkers(log.Log, sessionManager, tunnel, conn, options)
+	tunnel.WhenDone(func() {
+		workers.StartShutdown()
+		workers.WaitWorkersShutdown()
+	})
+
+	// signal to the session manager that we're ready to start accepting data.
+	// In practice, this means that we already have a valid TunnelInfo at this point
+	// (i.e., three way handshake has completed, and we have valid keys).
+	<-sessionManager.Ready
+	return tunnel
+}
+
+// TUN allows to use channels to read and write. It also OWNS the underlying connection.
+// TUN implements net.Conn
+type TUN struct {
+	TunDown          chan []byte
+	TunUp            chan []byte
+	conn             networkio.FramingConn
+	logger           model.Logger
+	closeOnce        sync.Once
+	hangup           chan any
+	readBuffer       *bytes.Buffer
+	session          *session.Manager
+	readDeadline     *time.Timer
+	readDeadlineDone chan any
+	whenDone         func()
+}
+
+// newTUN creates a new TUN.
+// This function TAKES OWNERSHIP of the conn.
+func NewTUN(logger model.Logger, conn networkio.FramingConn, session *session.Manager) *TUN {
+	return &TUN{
+		TunDown:          make(chan []byte),
+		TunUp:            make(chan []byte, 10),
+		conn:             conn,
+		closeOnce:        sync.Once{},
+		hangup:           make(chan any),
+		logger:           logger,
+		readBuffer:       &bytes.Buffer{},
+		readDeadlineDone: make(chan any),
+		session:          session,
+	}
+}
+
+// WhenDone registers a callback to be called on shutdown.
+// This is useful to propagate shutdown to workers.
+func (t *TUN) WhenDone(fn func()) {
+	t.whenDone = fn
+}
+
+func (t *TUN) Close() error {
+	t.closeOnce.Do(func() {
+		close(t.hangup)
+		// We OWN the connection
+		t.conn.Close()
+		// execute any shutdown callback
+		if t.whenDone != nil {
+			t.whenDone()
+		}
+	})
+	return nil
+}
+
+func (t *TUN) Read(data []byte) (int, error) {
+	// log.Printf("[tunbio] requested read")
+	for {
+		count, _ := t.readBuffer.Read(data)
+		if count > 0 {
+			// log.Printf("[tunbio] received %d bytes", len(data))
+			return count, nil
+		}
+		select {
+		case <-t.readDeadlineDone:
+			return 0, context.DeadlineExceeded
+		case extra := <-t.TunUp:
+			t.readBuffer.Write(extra)
+		case <-t.hangup:
+			return 0, net.ErrClosed
+		}
+	}
+}
+
+func (t *TUN) Write(data []byte) (int, error) {
+	// log.Printf("[tunbio] requested to write %d bytes", len(data))
+	select {
+	case t.TunDown <- data:
+		return len(data), nil
+	case <-t.hangup:
+		return 0, net.ErrClosed
+	}
+}
+
+// These methods are specific for TUNBio, not in TLSBio
+
+func (t *TUN) LocalAddr() net.Addr {
+	// TODO block or fail if session not ready
+	ip := t.session.TunnelInfo().IP
+	return &tunBioAddr{ip}
+}
+
+func (t *TUN) RemoteAddr() net.Addr {
+	// TODO block or fail if session not ready
+	gw := t.session.TunnelInfo().GW
+	return &tunBioAddr{gw}
+}
+
+func (t *TUN) SetDeadline(tm time.Time) error {
+	t.logger.Infof("TODO should set deadline", t)
+	return nil
+}
+
+func (t *TUN) SetReadDeadline(tm time.Time) error {
+	// If there's an existing timer, stop it
+	if t.readDeadline != nil {
+		t.readDeadline.Stop()
+	}
+	// Calculate the duration until the deadline
+	duration := time.Until(tm)
+	// Create a new timer
+	t.readDeadline = time.AfterFunc(duration, func() {
+		t.readDeadlineDone <- true
+	})
+	return nil
+}
+
+func (t *TUN) SetWriteDeadline(tm time.Time) error {
+	t.logger.Infof("TODO should set write deadline: %v", tm)
+	return nil
+}
+
+// tunBioAddr is the type of address returned by [Conn]
+type tunBioAddr struct {
+	addr string
+}
+
+var _ net.Addr = &tunBioAddr{}
+
+// Network implements net.Addr
+func (t *tunBioAddr) Network() string {
+	return "tunBioAddr"
+}
+
+// String implements net.Addr
+func (t *tunBioAddr) String() string {
+	return t.addr
+}

--- a/internal/tun/tun.go
+++ b/internal/tun/tun.go
@@ -5,6 +5,8 @@ package tun
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"net"
 	"os"
 	"sync"
@@ -16,12 +18,17 @@ import (
 	"github.com/ooni/minivpn/internal/session"
 )
 
+var (
+	ErrInitializationTimeout = errors.New("timeout while waiting for TUN to start")
+)
+
 // StartTUN initializes and starts the TUN device over the vpn.
-func StartTUN(conn networkio.FramingConn, options *model.Options) *TUN {
+// If the passed context expires before the TUN device is ready,
+func StartTUN(ctx context.Context, conn networkio.FramingConn, options *model.Options) (*TUN, error) {
 	// create a session
 	sessionManager, err := session.NewManager(log.Log)
 	if err != nil {
-		log.WithError(err).Fatal("tun.StartTUN")
+		return nil, err
 	}
 
 	// create the TUN that will OWN the connection
@@ -34,25 +41,23 @@ func StartTUN(conn networkio.FramingConn, options *model.Options) *TUN {
 		workers.WaitWorkersShutdown()
 	})
 
-	// Await for the signal from the session manager to known we're ready to start accepting data.
+	// Await for the signal from the session manager to tell us we're ready to start accepting data.
 	// In practice, this means that we already have a valid TunnelInfo at this point
 	// (i.e., three way handshake has completed, and we have valid keys).
 
-	// TODO(ainghazal): we need to timeout here.
-	<-sessionManager.Ready
-	return tunnel
+	select {
+	case <-ctx.Done():
+		return nil, ErrInitializationTimeout
+	case <-sessionManager.Ready:
+		return tunnel, nil
+	}
 }
 
 // TUN allows to use channels to read and write. It also OWNS the underlying connection.
 // TUN implements net.Conn
 type TUN struct {
-	logger model.Logger
-
-	// tunDown moves bytes down to the data channel.
-	tunDown chan []byte
-
-	// tunUp moves bytes up from the data channel.
-	tunUp chan []byte
+	// ensure idempotency.
+	closeOnce sync.Once
 
 	// conn is the underlying connection.
 	conn networkio.FramingConn
@@ -60,8 +65,8 @@ type TUN struct {
 	// hangup is used to let methods know the connection is closed.
 	hangup chan any
 
-	// ensure idempotency.
-	closeOnce sync.Once
+	// logger implements model.Logger
+	logger model.Logger
 
 	// network is the underlying network for the passed [networkio.FramingConn].
 	network string
@@ -69,32 +74,42 @@ type TUN struct {
 	// used to buffer reads from above.
 	readBuffer *bytes.Buffer
 
-	readDeadline  tunDeadline
-	writeDeadline tunDeadline
+	// readDeadline is used to set the read deadline.
+	readDeadline tunDeadline
 
+	// session is the session manager
 	session *session.Manager
+
+	// tunDown moves bytes down to the data channel.
+	tunDown chan []byte
+
+	// tunUp moves bytes up from the data channel.
+	tunUp chan []byte
 
 	// callback to be executed on shutdown.
 	whenDoneFn func()
+
+	// writeDeadline is used to set the write deadline.
+	writeDeadline tunDeadline
 }
 
 // newTUN creates a new TUN.
 // This function TAKES OWNERSHIP of the conn.
 func newTUN(logger model.Logger, conn networkio.FramingConn, session *session.Manager) *TUN {
 	return &TUN{
-		logger:        logger,
-		tunDown:       make(chan []byte),
-		tunUp:         make(chan []byte, 10),
-		conn:          conn,
-		hangup:        make(chan any),
-		closeOnce:     sync.Once{},
-		readBuffer:    &bytes.Buffer{},
-		network:       conn.LocalAddr().Network(),
-		readDeadline:  makeTUNDeadline(),
+		closeOnce:    sync.Once{},
+		conn:         conn,
+		hangup:       make(chan any),
+		logger:       logger,
+		network:      conn.LocalAddr().Network(),
+		readBuffer:   &bytes.Buffer{},
+		readDeadline: makeTUNDeadline(),
+		session:      session,
+		tunDown:      make(chan []byte),
+		tunUp:        make(chan []byte, 10),
+		// this function is explicitely set empty so that we can safely use a callback even if not set.
+		whenDoneFn:    func() {},
 		writeDeadline: makeTUNDeadline(),
-		session:       session,
-		whenDoneFn: func() {
-		},
 	}
 }
 
@@ -116,15 +131,13 @@ func (t *TUN) Close() error {
 }
 
 func (t *TUN) Read(data []byte) (int, error) {
-	// log.Printf("[tunbio] requested read")
 	for {
 		count, _ := t.readBuffer.Read(data)
 		if count > 0 {
 			// log.Printf("[tunbio] received %d bytes", len(data))
 			return count, nil
 		}
-		switch {
-		case isClosedChan(t.readDeadline.wait()):
+		if isClosedChan(t.readDeadline.wait()) {
 			return 0, os.ErrDeadlineExceeded
 		}
 		select {
@@ -139,9 +152,7 @@ func (t *TUN) Read(data []byte) (int, error) {
 }
 
 func (t *TUN) Write(data []byte) (int, error) {
-	// log.Printf("[tunbio] requested to write %d bytes", len(data))
-	switch {
-	case isClosedChan(t.writeDeadline.wait()):
+	if isClosedChan(t.writeDeadline.wait()) {
 		return 0, os.ErrDeadlineExceeded
 	}
 	select {
@@ -155,13 +166,11 @@ func (t *TUN) Write(data []byte) (int, error) {
 }
 
 func (t *TUN) LocalAddr() net.Addr {
-	// TODO block or fail if session not ready
 	ip := t.session.TunnelInfo().IP
 	return &tunBioAddr{ip, t.network}
 }
 
 func (t *TUN) RemoteAddr() net.Addr {
-	// TODO block or fail if session not ready
 	gw := t.session.TunnelInfo().GW
 	return &tunBioAddr{gw, t.network}
 }
@@ -182,7 +191,7 @@ func (t *TUN) SetWriteDeadline(tm time.Time) error {
 	return nil
 }
 
-// tunBioAddr is the type of address returned by [Conn]
+// tunBioAddr is the type of address returned by [*TUN]
 type tunBioAddr struct {
 	addr string
 	net  string

--- a/internal/tun/tundeadline.go
+++ b/internal/tun/tundeadline.go
@@ -1,0 +1,82 @@
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tun
+
+//
+// This file adapts code from net.Pipe in the Go standard library.
+//
+
+import (
+	"sync"
+	"time"
+)
+
+// tunDeadline is an abstraction for handling timeouts.
+type tunDeadline struct {
+	mu     sync.Mutex // Guards timer and cancel
+	timer  *time.Timer
+	cancel chan struct{} // Must be non-nil
+}
+
+func makeTUNDeadline() tunDeadline {
+	return tunDeadline{cancel: make(chan struct{})}
+}
+
+// set sets the point in time when the deadline will time out.
+// A timeout event is signaled by closing the channel returned by waiter.
+// Once a timeout has occurred, the deadline can be refreshed by specifying a
+// t value in the future.
+//
+// A zero value for t prevents timeout.
+func (d *tunDeadline) set(t time.Time) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.timer != nil && !d.timer.Stop() {
+		<-d.cancel // Wait for the timer callback to finish and close cancel
+	}
+	d.timer = nil
+
+	// Time is zero, then there is no deadline.
+	closed := isClosedChan(d.cancel)
+	if t.IsZero() {
+		if closed {
+			d.cancel = make(chan struct{})
+		}
+		return
+	}
+
+	// Time in the future, setup a timer to cancel in the future.
+	if dur := time.Until(t); dur > 0 {
+		if closed {
+			d.cancel = make(chan struct{})
+		}
+		d.timer = time.AfterFunc(dur, func() {
+			close(d.cancel)
+		})
+		return
+	}
+
+	// Time in the past, so close immediately.
+	if !closed {
+		close(d.cancel)
+	}
+}
+
+// wait returns a channel that is closed when the deadline is exceeded.
+func (d *tunDeadline) wait() chan struct{} {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.cancel
+}
+
+func isClosedChan(c <-chan struct{}) bool {
+	select {
+	case <-c:
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
This is the seventh (and in a sense, last) commit in the series of incremental refactoring of the current minivpn tree. With this package we have all the needed layers to start reasoning about the complete architecture.

TUN uses a similar strategy to the TLSBio in the tlssession package: it uses channels to communicate with the layer below (the data channel), and it buffers reads.

Reference issue: https://github.com/ooni/minivpn/issues/47