### PR TITLE
feat: track netmask passed by the remote

### DIFF
--- a/internal/model/options.go
+++ b/internal/model/options.go
@@ -182,9 +182,19 @@ func (o *Options) ServerOptionsString() string {
 // - during the handshake (mtu).
 // - after server pushes config options(ip, gw).
 type TunnelInfo struct {
-	MTU    int
-	IP     string
-	GW     string
+	// GW is the Route Gateway.
+	GW string
+
+	// IP is the assigned IP.
+	IP string
+
+	// MTU is the configured MTU pushed by the remote.
+	MTU int
+
+	// NetMask is the netmask configured on the TUN interface, pushed by the ifconfig command.
+	NetMask string
+
+	// PeerID is the peer-id assigned to us by the remote.
 	PeerID int
 }
 
@@ -197,9 +207,12 @@ func NewTunnelInfoFromPushedOptions(opts map[string][]string) *TunnelInfo {
 	} else if r := opts["route-gateway"]; len(r) >= 1 {
 		t.GW = r[0]
 	}
-	ip := opts["ifconfig"]
-	if len(ip) >= 1 {
-		t.IP = ip[0]
+	ifconfig := opts["ifconfig"]
+	if len(ifconfig) >= 1 {
+		t.IP = ifconfig[0]
+	}
+	if len(ifconfig) >= 2 {
+		t.NetMask = ifconfig[1]
 	}
 	peerID := opts["peer-id"]
 	if len(peerID) == 1 {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -336,6 +336,7 @@ func (m *Manager) UpdateTunnelInfo(ti *model.TunnelInfo) {
 	m.tunnelInfo.IP = ti.IP
 	m.tunnelInfo.GW = ti.GW
 	m.tunnelInfo.PeerID = ti.PeerID
+	m.tunnelInfo.NetMask = ti.NetMask
 
 	m.logger.Infof("Tunnel IP: %s", ti.IP)
 	m.logger.Infof("Gateway IP: %s", ti.GW)
@@ -347,9 +348,10 @@ func (m *Manager) TunnelInfo() model.TunnelInfo {
 	defer m.mu.Unlock()
 	m.mu.Lock()
 	return model.TunnelInfo{
-		MTU:    m.tunnelInfo.MTU,
-		IP:     m.tunnelInfo.IP,
-		GW:     m.tunnelInfo.GW,
-		PeerID: m.tunnelInfo.PeerID,
+		GW:      m.tunnelInfo.GW,
+		IP:      m.tunnelInfo.IP,
+		MTU:     m.tunnelInfo.MTU,
+		NetMask: m.tunnelInfo.NetMask,
+		PeerID:  m.tunnelInfo.PeerID,
 	}
 }

--- a/internal/tun/tun.go
+++ b/internal/tun/tun.go
@@ -3,7 +3,6 @@ package tun
 import (
 	"bytes"
 	"context"
-	"errors"
 	"net"
 	"os"
 	"sync"
@@ -13,10 +12,6 @@ import (
 	"github.com/ooni/minivpn/internal/model"
 	"github.com/ooni/minivpn/internal/networkio"
 	"github.com/ooni/minivpn/internal/session"
-)
-
-var (
-	ErrInitializationTimeout = errors.New("timeout while waiting for TUN to start")
 )
 
 // StartTUN initializes and starts the TUN device over the vpn.
@@ -44,7 +39,7 @@ func StartTUN(ctx context.Context, conn networkio.FramingConn, options *model.Op
 
 	select {
 	case <-ctx.Done():
-		return nil, ErrInitializationTimeout
+		return nil, ctx.Err()
 	case <-sessionManager.Ready:
 		return tunnel, nil
 	}

--- a/internal/tun/tun.go
+++ b/internal/tun/tun.go
@@ -206,3 +206,7 @@ func (t *tunBioAddr) Network() string {
 func (t *tunBioAddr) String() string {
 	return t.addr
 }
+
+func (t *TUN) NetMask() net.IPMask {
+	return net.IPMask(net.ParseIP(t.session.TunnelInfo().NetMask))
+}


### PR DESCRIPTION
We were not tracking the netmask passed by the remote (in the ifconfig option). This will be used to set up routes in the integration branch.

While there, I also changed the type of error returned by the StartTUN constructor, so that it returns the context Error() itself.